### PR TITLE
better explain how to start the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ import './style-1.css?skip';
 |**[`include`](#minify)**|`{boolean}`|`N/A`|Just setting this parameter will include the css even when defaultSkip is on. This may be useful if you just want to "litify" or "web-componentize" a .css/.scss/.less file. E.g:  `import './style-2.css?include'`. **Note**: `include` will take preference over `skip`.
 
 # Need an example? 
-Navigate to [test-app](./test-app), and execute: `npm start`. It will launch an express server @ localhost:3000. Then, run `webpack`. (Remember to have webpack-cli installed)
+Build lit-scss-loader with `npm run build`, then navigate to [test-app](./test-app) and execute: `npm start`. It will launch an express server @ localhost:3000. Then, run `webpack`. (Remember to have webpack-cli installed)
 
 # Legacy Support
 The loader automatically injects code (e.g. `import {css} from 'lit-element';`) into your files, therefore, pay attention if you need es5 / legacy browsers support. As [LambyPants](https://github.com/drdreo/lit-scss-loader/issues/3) mentioned, you might have to adopt your loaders configuration to also test for ```/\.js$|\.ts$|\.s(c|a)ss$/``` and transform it to your needed language support.


### PR DESCRIPTION
Explain to users that lit-scss-loader has to be built first, because the example app has a dependency on '../dist/'